### PR TITLE
Openjdk19 maven

### DIFF
--- a/Correlator/pom.xml
+++ b/Correlator/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 	        <groupId>junit</groupId>
 	        <artifactId>junit</artifactId>
-	        <version>4.12</version>
+	        <version>4.13.1</version>
         	<scope>test</scope>
         </dependency>
     </dependencies>

--- a/Correlator/pom.xml
+++ b/Correlator/pom.xml
@@ -67,29 +67,10 @@
 	        <artifactId>junit</artifactId>
 	        <version>4.12</version>
         	<scope>test</scope>
-	</dependency>
-	    <dependency>
-        <groupId>org.openjfx</groupId>
-        <artifactId>javafx-graphics </artifactId>
-        <version>20</version>
-        <classifier>win</classifier>
-    </dependency>
-    <dependency>
-        <groupId>org.openjfx</groupId>
-        <artifactId>javafx-graphics </artifactId>
-        <version>20</version>
-        <classifier>linux</classifier>
-    </dependency>
-    <dependency>
-        <groupId>org.openjfx</groupId>
-        <artifactId>javafx-graphics </artifactId>
-        <version>20</version>
-        <classifier>mac</classifier>
-    </dependency>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
-		   
 		  <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
@@ -125,6 +106,35 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
             <version>3.2.0</version>
+            
+            <dependencies>
+				<!-- These are required for the shaded Jar build -->
+				<dependency>
+			        <groupId>org.openjfx</groupId>
+			        <artifactId>javafx-graphics </artifactId>
+			        <version>20</version>
+			        <classifier>win</classifier>
+			    </dependency>
+			    <dependency>
+			        <groupId>org.openjfx</groupId>
+			        <artifactId>javafx-graphics </artifactId>
+			        <version>20</version>
+			        <classifier>linux</classifier>
+			    </dependency>
+			    <dependency>
+			        <groupId>org.openjfx</groupId>
+			        <artifactId>javafx-graphics </artifactId>
+			        <version>20</version>
+			        <classifier>mac</classifier>
+			    </dependency>
+			    <dependency>
+			        <groupId>org.openjfx</groupId>
+			        <artifactId>javafx-graphics </artifactId>
+			        <version>20</version>
+			        <classifier>mac-aarch64</classifier>
+			    </dependency>
+			</dependencies>
+
             <executions>
                 <execution>
                     <phase>package</phase>


### PR DESCRIPTION
Updates to the build pom.xml to support Mac-aarch64 (M1 and M2) systems.